### PR TITLE
Update phpspreadsheet version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ Release notes for the Sheets to Tables Craft CMS plugin.
 
 ## Unreleased 1.2.1
 
-### Added
-- Updated PhpSpreadsheet to 5.7 (on supported environments).
+### Changed
+- Updated PhpSpreadsheet to 1.30.4 / 2.1.16 / 5.7.0 (on supported environments).
+
+
 
 ## 1.2.0 - 2024-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Release notes for the Sheets to Tables Craft CMS plugin.
 
 
 
+## Unreleased 1.2.1
+
+### Added
+- Added support for PhpSpreadsheet 5.3.
+
 ## 1.2.0 - 2024-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Release notes for the Sheets to Tables Craft CMS plugin.
 ## Unreleased 1.2.1
 
 ### Added
-- Added support for PhpSpreadsheet 5.7.
+- Updated PhpSpreadsheet to 5.7 (on supported environments).
 
 ## 1.2.0 - 2024-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Release notes for the Sheets to Tables Craft CMS plugin.
 ## Unreleased 1.2.1
 
 ### Added
-- Added support for PhpSpreadsheet 5.3.
+- Added support for PhpSpreadsheet 5.7.
 
 ## 1.2.0 - 2024-04-14
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "craftcms/cms": "^3.0 || ^4.0 || ^5.0",
         "php": "^7.2.5 || ^8.0",
-        "phpoffice/phpspreadsheet": "^1.5 || ^2.0 || ^5.3"
+        "phpoffice/phpspreadsheet": "^1.30.4 || ^2.1.15 || ^5.7"
     },
     "require-dev": {
         "craftcms/rector": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "craftcms/cms": "^3.0 || ^4.0 || ^5.0",
         "php": "^7.2.5 || ^8.0",
-        "phpoffice/phpspreadsheet": "^1.5 || ^2.0"
+        "phpoffice/phpspreadsheet": "^1.5 || ^2.0 || ^5.3"
     },
     "require-dev": {
         "craftcms/rector": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "craftcms/cms": "^3.0 || ^4.0 || ^5.0",
         "php": "^7.2.5 || ^8.0",
-        "phpoffice/phpspreadsheet": "^1.30.4 || ^2.1.15 || ^5.7"
+        "phpoffice/phpspreadsheet": "^1.30.4 || ^2.1.16 || ^5.7"
     },
     "require-dev": {
         "craftcms/rector": "dev-main",


### PR DESCRIPTION
**Note:**
Added support for _PhpSpreadsheet_ `5.7` for Craft CMS `5.9+` update.